### PR TITLE
Added Gun Modifier to KillReward()

### DIFF
--- a/XPForKills.cs
+++ b/XPForKills.cs
@@ -99,8 +99,9 @@ namespace PhaserArray.XPForKills
 		{
 			var limbModifier = GetLimbModifier(limb);
 			var getGunModifier = Config.GunMultipliers.FirstOrDefault(m => m.Id == murderer.Player.equipment.asset.id);
-			if (getGunModifier == null) getGunModifier = 1f;
-			var killReward = (int)(Config.KillXP * limbModifier * getGunModifier);
+			float GunModifier = 1f;
+			if (getGunModifier != null) GunModifier = getGunModifier.Multiplier;
+			var killReward = (int)(Config.KillXP * limbModifier * GunModifier);
 			
 			if (killReward == 0) return;
 			var realXPDelta = ChangeExperience(murderer, killReward);

--- a/XPForKills.cs
+++ b/XPForKills.cs
@@ -6,6 +6,7 @@ using Rocket.Unturned.Chat;
 using Rocket.Core.Plugins;
 using Rocket.Core.Logging;
 using SDG.Unturned;
+using XPForKills;
 
 namespace PhaserArray.XPForKills
 {
@@ -97,11 +98,13 @@ namespace PhaserArray.XPForKills
 		private void KillReward(UnturnedPlayer murderer, UnturnedPlayer victim, ELimb limb)
 		{
 			var limbModifier = GetLimbModifier(limb);
-			var killReward = (int)(Config.KillXP * limbModifier);
-
+			var getGunModifier = Config.GunMultipliers.FirstOrDefault(m => m.Id == murderer.Player.equipment.asset.id);
+			if (getGunModifier == null) getGunModifier = 1f;
+			var killReward = (int)(Config.KillXP * limbModifier * getGunModifier);
+			
 			if (killReward == 0) return;
 			var realXPDelta = ChangeExperience(murderer, killReward);
-
+			
 			if (!Config.DisableMessages) return;
 			UnturnedChat.Say(murderer, Instance.Translate("experience_kill_reward", victim.CharacterName, realXPDelta));
 		}


### PR DESCRIPTION
Finally Getting the Multiplier from the murderer's equipped gun. If it doesnt exists it just returns 1. Not sure what will happen if the murderer for some reason doesn't have an item equipped. But even so that shouldnt throw an error right?